### PR TITLE
fix: fix empty env value

### DIFF
--- a/src/db/kv.ts
+++ b/src/db/kv.ts
@@ -18,7 +18,7 @@ class KV {
 
   static async getInstance(): Promise<KV> {
     if (this.instance === null) {
-      const KV_PATH = Deno.env.get("KV_PATH");
+      const KV_PATH = Deno.env.get("KV_PATH") || undefined;
       const kv = await Deno.openKv(KV_PATH);
       this.instance = new KV(kv);
     }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -12,7 +12,7 @@ import {
 } from "../controllers/api.ts";
 import { sendAPIAccessLog } from "../services/log.ts";
 
-const apiKeys = Deno.env.get("API_KEYS")?.split(",") ?? [];
+const apiKeys = Deno.env.get("API_KEYS")?.split(",").filter(Boolean) ?? [];
 
 const api = new Hono();
 


### PR DESCRIPTION
環境変数が空文字列だった場合、`undefined` となるように修正