### PR TITLE
fix: return 404 for requests with queries

### DIFF
--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -11,6 +11,9 @@ export const redirect = async (c: Context) => {
   const { host, param } = getRequest(c);
   if (!host || !param) return c.notFound();
 
+  const query = c.req.query();
+  if (Object.keys(query).length > 0) return c.notFound();
+
   const url = await getURL(host, param);
   if (!url) return c.notFound();
 


### PR DESCRIPTION
クエリを含むリクエストに対しては 404 を返すように修正